### PR TITLE
Move and change close button in visualizer modal

### DIFF
--- a/web/src/app/c/[slug]/address/page.tsx
+++ b/web/src/app/c/[slug]/address/page.tsx
@@ -62,8 +62,22 @@ export default function AddressPage({ params }: { params: Promise<{ slug: string
   });
 
   const onReset = () => {
-    if (typeof window !== "undefined") window.localStorage.removeItem("joytree_address");
-    reset();
+    const hasWindow = typeof window !== "undefined";
+    if (hasWindow) window.localStorage.removeItem("joytree_address");
+    reset({
+      recipientName: "",
+      phone: hasWindow ? (window.localStorage.getItem("joytree_mobile") || "") : "",
+      email: "",
+      line1: "",
+      line2: "",
+      city: "",
+      state: "",
+      pincode: "",
+      country: "India",
+      alternatePhone: "",
+      landmark: "",
+      addressType: "home",
+    });
   };
 
   return (

--- a/web/src/app/c/[slug]/gifts/[giftId]/page.tsx
+++ b/web/src/app/c/[slug]/gifts/[giftId]/page.tsx
@@ -120,13 +120,15 @@ export default function GiftDetailsPage({ params }: { params: Promise<{ slug: st
       <Modal
         open={visualizeOpen}
         onClose={() => setVisualizeOpen(false)}
-        footer={
-          <>
-            <button className="px-3 py-2 border border-gray-300 rounded text-gray-800" onClick={() => setVisualizeOpen(false)}>Close</button>
-          </>
-        }
       >
-        <div className="w-full" style={{height: "50vh" }}>
+        <div className="w-full relative" style={{height: "50vh" }}>
+          <button
+            aria-label="Close"
+            onClick={() => setVisualizeOpen(false)}
+            className="absolute top-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-700 hover:bg-gray-100"
+          >
+            <span aria-hidden>×</span>
+          </button>
           <iframe
             src={visualizeUrl}
             title="3D Model"


### PR DESCRIPTION
Move the visualizer modal's close button to the top-right and replace its text with an 'X' symbol.

---
<a href="https://cursor.com/background-agent?bcId=bc-604e4cf0-41aa-4175-a3bd-3ecec8f69e7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-604e4cf0-41aa-4175-a3bd-3ecec8f69e7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Address form reset now pre-fills sensible defaults and retains your mobile number when available.
  * Gift modal now includes an in-content Close button at the top-right of the preview.

* Bug Fixes
  * Resetting the address form no longer leaves fields blank; it initializes with default values for a smoother experience.
  * Close functionality in the gift modal remains available after UI adjustments, ensuring consistent behavior without relying on the footer button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->