### PR TITLE
Handle joytree logo click navigation

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,22 +1,77 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 export default function Header() {
   const pathname = usePathname();
+  const router = useRouter();
 
   // Hide header on gifts page route: /c/[slug]/gifts and its children
   const shouldHideHeader = /^\/c\/[^/]+\/gifts(\/.*)?$/.test(pathname || "");
 
   if (shouldHideHeader) return null;
 
+  const handleLogoClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    
+    // Extract slug from pathname for campaign pages
+    const slugMatch = pathname?.match(/^\/c\/([^/]+)/);
+    const slug = slugMatch ? slugMatch[1] : null;
+
+    // 1. On details page -> Do nothing
+    if (pathname?.match(/^\/c\/[^/]+\/details$/)) {
+      return;
+    }
+
+    // 2. On address page -> Redirect to gifts page
+    if (pathname?.match(/^\/c\/[^/]+\/address$/)) {
+      if (slug) {
+        router.push(`/c/${slug}/gifts`);
+      }
+      return;
+    }
+
+    // 3. On confirm page -> Redirect to gifts page
+    if (pathname?.match(/^\/c\/[^/]+\/confirm$/)) {
+      if (slug) {
+        router.push(`/c/${slug}/gifts`);
+      }
+      return;
+    }
+
+    // 4. On thank you page (order summary) -> Redirect to auth page
+    if (pathname?.match(/^\/order\/[^/]+\/summary$/)) {
+      // Extract slug from localStorage if available
+      const orderId = pathname.match(/^\/order\/([^/]+)\/summary$/)?.[1];
+      let campaignSlug = slug; // Try to get from URL first
+      
+      // If not in URL, try to get from localStorage
+      if (!campaignSlug && orderId && typeof window !== "undefined") {
+        try {
+          const orderData = window.localStorage.getItem(`joytree_order_${orderId}`);
+          if (orderData) {
+            const parsed = JSON.parse(orderData);
+            campaignSlug = parsed.campaignSlug;
+          }
+        } catch {}
+      }
+      
+      if (campaignSlug) {
+        router.push(`/c/${campaignSlug}/auth`);
+      }
+      return;
+    }
+
+    // Default behavior: go to home
+    router.push("/");
+  };
+
   return (
     <div className="px-2 pt-2">
-      <Link href="/" aria-label="Joytree Home">
+      <button onClick={handleLogoClick} aria-label="Joytree Home" className="cursor-pointer">
         <Image src="/JoytreeLogo.png" alt="Joytree" width={96} height={24} priority />
-      </Link>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Implement conditional navigation for the Joytree logo based on the current page, redirecting to specific routes or doing nothing as per requirements.

The navigation logic now handles different page contexts:
- On details page, clicking the logo does nothing.
- On address and confirm pages, it redirects to the gifts page for the current campaign.
- On the thank you page, it redirects to the auth page, attempting to retrieve the campaign slug from local storage if not present in the URL.
- For all other pages, it navigates to the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-21534fa8-d919-4b90-9ad0-557f973e2860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21534fa8-d919-4b90-9ad0-557f973e2860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Header logo now provides context-aware navigation:
    - Stays on details pages.
    - From address/confirm pages, returns to the related gifts page.
    - From order summary, goes to the campaign’s sign-in page.
    - Otherwise, returns to the home page.
* **Refactor**
  * Updated header logo navigation handling for more consistent, predictable behavior across routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->