### PR TITLE
Handle joytree logo click navigation

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -2,16 +2,67 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 export default function Header() {
   const pathname = usePathname();
+  const router = useRouter();
 
   // Hide header on gifts page route: /c/[slug]/gifts and its children
   const shouldHideHeader = /^\/c\/[^/]+\/gifts(\/.*)?$/.test(pathname || "");
 
   if (shouldHideHeader) return null;
 
+  // Check if we're on details page: /c/[slug]/details
+  const isDetailsPage = /^\/c\/[^/]+\/details$/.test(pathname || "");
+
+  // Check if we're on address page: /c/[slug]/address
+  const isAddressPage = /^\/c\/[^/]+\/address$/.test(pathname || "");
+
+  // Handle logo click
+  const handleLogoClick = (e: React.MouseEvent) => {
+    if (isDetailsPage) {
+      // Do nothing on details page
+      e.preventDefault();
+      return;
+    }
+
+    if (isAddressPage) {
+      // Redirect to gifts page
+      e.preventDefault();
+      const slugMatch = pathname?.match(/^\/c\/([^/]+)\//);
+      if (slugMatch && slugMatch[1]) {
+        router.push(`/c/${slugMatch[1]}/gifts`);
+      }
+      return;
+    }
+
+    // Default behavior for other pages (handled by Link)
+  };
+
+  // For details page, render as non-clickable
+  if (isDetailsPage) {
+    return (
+      <div className="px-2 pt-2">
+        <div className="cursor-default">
+          <Image src="/JoytreeLogo.png" alt="Joytree" width={96} height={24} priority />
+        </div>
+      </div>
+    );
+  }
+
+  // For address page or other pages with custom navigation
+  if (isAddressPage) {
+    return (
+      <div className="px-2 pt-2">
+        <button onClick={handleLogoClick} className="cursor-pointer" aria-label="Back to Gifts">
+          <Image src="/JoytreeLogo.png" alt="Joytree" width={96} height={24} priority />
+        </button>
+      </div>
+    );
+  }
+
+  // Default behavior for other pages
   return (
     <div className="px-2 pt-2">
       <Link href="/" aria-label="Joytree Home">


### PR DESCRIPTION
Add conditional navigation to the Joytree logo to disable clicks on the details page and redirect to the gifts page from the address page.

---
<a href="https://cursor.com/background-agent?bcId=bc-f35bf623-5825-4ef2-a624-c26bd3caa3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f35bf623-5825-4ef2-a624-c26bd3caa3e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context-aware header logo behavior:
    * On details pages, the logo is shown but not clickable, preventing accidental navigation.
    * On address pages, clicking the logo takes you directly to the related gifts page for the same item.
    * On all other pages, the logo behaves as a regular link to home.
  * Header visibility remains unchanged on gifts routes (still hidden), preserving prior behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->